### PR TITLE
Fix package name at the beginning

### DIFF
--- a/android/app/src/main/java/com/reactnativechallenge/MainActivity.java
+++ b/android/app/src/main/java/com/reactnativechallenge/MainActivity.java
@@ -1,5 +1,6 @@
-import android.os.Bundle;
 package com.reactnativechallenge;
+
+import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
 


### PR DESCRIPTION
I moved the package name at the beginning of the MainActivity to avoid a building error.